### PR TITLE
FIX: remove git hash from home

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,6 +2,5 @@ class HomeController < ApplicationController
   allow_unauthenticated_access
 
   def index
-    @git_commit = `git rev-parse --short HEAD`.chomp
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,7 +2,6 @@
   <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl md:text-6xl mb-6">
     GradeB🤖t coming soon....
   </h1>
-  <p class="text-lg text-gray-600">Current commit: <%= @git_commit %></p>
   <div class="mt-6">
     <% if authenticated? %>
       <%= link_to session_path, 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,6 @@ All notable changes to this project will be documented in this file.
 - Created `UserToken` model with `access_token`, `refresh_token`, `expires_at`, validations, `default_scope`, and `most_recent_for` method.
 - Added migration to create `user_tokens` table with references to `users` and timestamps.
 - Added tests for `UserToken` covering `most_recent_for`, validations, default scope ordering, `expired?`, and `will_expire_soon?` methods.
-- Added `git_commit` to `HomeController` and displayed it on the home page.
 - Added `Current` module to manage the current session and user.
 - Added `Authentication` concern to handle authentication.
 - Added `SessionsController` to handle session creation and destruction.


### PR DESCRIPTION
This pull request removes the display of the current Git commit hash from the home page and updates the changelog to reflect this change. The most important changes are outlined below:

### Removal of Git commit display:

* [`app/controllers/home_controller.rb`](diffhunk://#diff-2e1b0bda5d1af14b6acbbff496f78d7343528dcd5d1f58aa7259c9b73f2deb5aL5): Removed the `@git_commit` instance variable, which previously fetched the current short Git commit hash.
* [`app/views/home/index.html.erb`](diffhunk://#diff-70acf32a949fd60a5a3d1ae8bbca9090058a7f011f201c41e6a8b1a51ea12c02L5): Removed the paragraph displaying the current Git commit hash on the home page.

### Documentation update:

* [`docs/changelog.md`](diffhunk://#diff-77f023b99d3d58008351d3e82fc06e6d06ba1bc2da9e41be6329b7fa4f419f05L11): Updated the changelog to remove the entry about adding `git_commit` to `HomeController` and displaying it on the home page.