### PR TITLE
TEST: Remove tailwind classes from views

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ See: [Changelog](/docs/changelog.md)
 
 1. `kamal deploy` fails on step #12
    - Run `kamal prune all` and then `kamal deploy --verbose` 
+
+### Worst Bug Ever
+- [Styles not loading properly. #534 - tailwindcss-rails](https://github.com/rails/tailwindcss-rails/issues/534#issuecomment-2848449567)
    
 ## Competition 
 - [EssayGrader](https://www.essaygrader.ai/)

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,45 +1,37 @@
-<div class="flex flex-col sm:px-6 lg:px-8">
-  <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl md:text-6xl mb-6">
+<div>
+  <h1>
     Testing, testing 1, 2, 3
   </h1>
-  <p class="flex items-center gap-2">
+  <p>
     Here is an svg:
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
       <path stroke-linecap="round" stroke-linejoin="round" d="M14.25 9.75 16.5 12l-2.25 2.25m-4.5 0L7.5 12l2.25-2.25M6 20.25h12A2.25 2.25 0 0 0 20.25 18V6A2.25 2.25 0 0 0 18 3.75H6A2.25 2.25 0 0 0 3.75 6v12A2.25 2.25 0 0 0 6 20.25Z" />
     </svg>
   </p>
-  <div class="mt-6">
-    <% if authenticated? %>
-      <%= link_to session_path, 
-          data: { turbo_method: :delete },
-          class: "inline-flex items-center justify-center gap-x-2 px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700" do %>
-          <svg class="size-5 text-white group-hover:text-blue-600" 
-              xmlns="http://www.w3.org/2000/svg" 
-              fill="none" 
-              viewBox="0 0 24 24" 
-              stroke-width="1.75" 
-              stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l-3 3m0 0l3 3m-3-3h12.75" />
-          </svg>
-          <div class="relative mr-1">
-            <img src="<%= Current.user&.profile_picture_url %>" alt="<%= Current.user&.name || 'User' %>" class="size-6 rounded-full object-cover border border-gray-200">
-          </div>
-          <span>Sign out</span>
-      <% end %>
-    <% else %>
-      <%= button_to "/auth/google_oauth2",
-        method: :post,
-        data: { turbo: false },
-        class: "group flex items-center justify-center gap-3 w-full md:w-auto py-4 px-8 md:px-10 text-base md:text-lg font-medium bg-white text-gray-800 hover:text-indigo-700 hover:bg-indigo-50/70 hover:scale-[1.03] hover:border-indigo-300 hover:shadow-xl active:scale-[0.98] active:bg-indigo-100 active:shadow-inner rounded-xl shadow-lg transition-all duration-200 ease-in-out transform border border-gray-200" do %>
-          <div class="w-6 h-6 flex-shrink-0">
-          <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" style="display: block;">
-            <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
-            <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/>
-            <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/>
-            <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
-          </svg>
-        </div>
-        <span class="group-hover:text-blue-700 group-active:text-blue-800 transition-colors duration-200 font-semibold">Sign in</span>
-      <% end %>
+  <% if authenticated? %>
+    <%= link_to session_path, data: { turbo_method: :delete } do %>
+      <svg class="size-5 text-white group-hover:text-blue-600" 
+          xmlns="http://www.w3.org/2000/svg" 
+          fill="none" 
+          viewBox="0 0 24 24" 
+          stroke-width="1.75" 
+          stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l-3 3m0 0l3 3m-3-3h12.75" />
+      </svg>
+      <div>
+        <img src="<%= Current.user&.profile_picture_url %>" alt="<%= Current.user&.name || 'User' %>" >
+      </div>
+      <span>Sign out</span>
     <% end %>
+  <% else %>
+    <%= button_to "/auth/google_oauth2", method: :post, data: { turbo: false } do %>
+      <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" style="display: block;">
+        <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
+        <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/>
+        <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/>
+        <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
+      </svg>
+      <span >Sign in</span>
+    <% end %>
+  <% end %>
 </div>

--- a/app/views/home/index.html.erb.bak
+++ b/app/views/home/index.html.erb.bak
@@ -1,0 +1,45 @@
+<div class="flex flex-col sm:px-6 lg:px-8">
+  <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl md:text-6xl mb-6">
+    Testing, testing 1, 2, 3
+  </h1>
+  <p class="flex items-center gap-2">
+    Here is an svg:
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M14.25 9.75 16.5 12l-2.25 2.25m-4.5 0L7.5 12l2.25-2.25M6 20.25h12A2.25 2.25 0 0 0 20.25 18V6A2.25 2.25 0 0 0 18 3.75H6A2.25 2.25 0 0 0 3.75 6v12A2.25 2.25 0 0 0 6 20.25Z" />
+    </svg>
+  </p>
+  <div class="mt-6">
+    <% if authenticated? %>
+      <%= link_to session_path, 
+          data: { turbo_method: :delete },
+          class: "inline-flex items-center justify-center gap-x-2 px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700" do %>
+          <svg class="size-5 text-white group-hover:text-blue-600" 
+              xmlns="http://www.w3.org/2000/svg" 
+              fill="none" 
+              viewBox="0 0 24 24" 
+              stroke-width="1.75" 
+              stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l-3 3m0 0l3 3m-3-3h12.75" />
+          </svg>
+          <div class="relative mr-1">
+            <img src="<%= Current.user&.profile_picture_url %>" alt="<%= Current.user&.name || 'User' %>" class="size-6 rounded-full object-cover border border-gray-200">
+          </div>
+          <span>Sign out</span>
+      <% end %>
+    <% else %>
+      <%= button_to "/auth/google_oauth2",
+        method: :post,
+        data: { turbo: false },
+        class: "group flex items-center justify-center gap-3 w-full md:w-auto py-4 px-8 md:px-10 text-base md:text-lg font-medium bg-white text-gray-800 hover:text-indigo-700 hover:bg-indigo-50/70 hover:scale-[1.03] hover:border-indigo-300 hover:shadow-xl active:scale-[0.98] active:bg-indigo-100 active:shadow-inner rounded-xl shadow-lg transition-all duration-200 ease-in-out transform border border-gray-200" do %>
+          <div class="w-6 h-6 flex-shrink-0">
+          <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" style="display: block;">
+            <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
+            <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/>
+            <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/>
+            <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
+          </svg>
+        </div>
+        <span class="group-hover:text-blue-700 group-active:text-blue-800 transition-colors duration-200 font-semibold">Sign in</span>
+      <% end %>
+    <% end %>
+</div>

--- a/app/views/layouts/application.html.erb.bak
+++ b/app/views/layouts/application.html.erb.bak
@@ -23,7 +23,7 @@
   </head>
 
   <body>
-    <main>
+    <main class="container mx-auto mt-28 px-5 flex">
       <%= yield %>
     </main>
   </body>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2025-05-03]
+
+### Removed
+- Removed all classes from `application.html.erb` and `home/index.html.erb`, created backups of each.
+
 ## [2025-05-02]
 
 ### Added


### PR DESCRIPTION
This pull request introduces several changes across multiple files, focusing on simplifying the HTML structure, removing unused CSS classes, and documenting these changes in the changelog. It also includes the addition of backup files for key views. Below is a summary of the most important changes:

### Simplification of HTML structure and removal of CSS classes:
* Removed all CSS classes from the `div`, `h1`, `p`, and `button` elements in `app/views/home/index.html.erb`, simplifying the structure and reducing reliance on custom styling. [[1]](diffhunk://#diff-70acf32a949fd60a5a3d1ae8bbca9090058a7f011f201c41e6a8b1a51ea12c02L1-R12) [[2]](diffhunk://#diff-70acf32a949fd60a5a3d1ae8bbca9090058a7f011f201c41e6a8b1a51ea12c02L24-R34)
* Removed the `class` attribute from the `<main>` element in `app/views/layouts/application.html.erb`.

### Backup files for views:
* Added a backup file `app/views/home/index.html.erb.bak` containing the original structure and CSS classes for `home/index.html.erb`.
* Added a backup file `app/views/layouts/application.html.erb.bak` containing the original structure and CSS classes for `application.html.erb`.

### Documentation updates:
* Updated `docs/changelog.md` to include a new entry documenting the removal of all classes from `application.html.erb` and `home/index.html.erb`, as well as the creation of backup files.

### Minor additions:
* Added a new "Worst Bug Ever" section to `README.md` with a link to a reported issue.