### PR TITLE
Test/add remote builder

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -84,6 +84,9 @@ asset_path: /rails/public/assets
 # Configure the image builder.
 builder:
   arch: amd64
+  remote: ssh://jesse@34.44.244.114
+  cache:
+    type: registry
 
   # # Build image via remote server (useful for faster amd64 builds on arm64 computers)
   # remote: ssh://docker@docker-builder-server

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 - Removed all classes from `application.html.erb` and `home/index.html.erb`, created backups of each.
+- Added remote build to `deploy.yml`.
 
 ## [2025-05-02]
 


### PR DESCRIPTION
This pull request introduces a remote build configuration for the image builder in the deployment settings and updates the changelog to reflect this addition.

### Deployment Configuration Updates:
* [`config/deploy.yml`](diffhunk://#diff-fa61612ba96bd682e6fcf1734a4558f3569972a070a4fe902b85972a485b6a36R87-R89): Added a `remote` field specifying an SSH URL and a `cache` section with a `type` set to `registry` for the image builder configuration. This enables remote builds, potentially improving build performance on specific architectures.

### Documentation Updates:
* [`docs/changelog.md`](diffhunk://#diff-77f023b99d3d58008351d3e82fc06e6d06ba1bc2da9e41be6329b7fa4f419f05R8): Updated the changelog to include the addition of the remote build configuration in `deploy.yml`.