### PR TITLE
Feature/create selected document model and migration

### DIFF
--- a/app/models/selected_document.rb
+++ b/app/models/selected_document.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: selected_documents
+#
+# id               :integer          not null, primary key
+# assignment_id    :integer          not null, foreign key
+# google_doc_id    :string           not null
+# title            :string           not null
+# url              :string           not null
+# created_at       :datetime         not null
+# updated_at       :datetime         not null
+#
+# Indexes
+#
+#  index_selected_documents_on_assignment_id  (assignment_id)
+#
+class SelectedDocument < ApplicationRecord
+  belongs_to :assignment
+
+  validates :assignment, presence: true
+  validates :google_doc_id, presence: true
+  validates :title, presence: true
+  validates :url, presence: true
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,7 @@
 <div class="flex flex-col items-center justify-center text-center mx-auto">
   <%= image_tag "gradebot-logo.png", class: "w-2/3 max-w-md" %>
   <p class="text-gray-700 font-semibold text-lg mt-6">Coming soon...</p>
+  <p class="text-gray-700 font-light text-lg mt-6">✅ Just finished: Selected Document Model</p>
   <div class="mt-6">
     <% if authenticated? %>
       <%= link_to session_path, 

--- a/db/migrate/20250503213853_create_selected_documents.rb
+++ b/db/migrate/20250503213853_create_selected_documents.rb
@@ -1,0 +1,12 @@
+class CreateSelectedDocuments < ActiveRecord::Migration[8.0]
+  def change
+    create_table :selected_documents do |t|
+      t.references :assignment, null: false, foreign_key: true
+      t.string :google_doc_id, null: false
+      t.string :title, null: false
+      t.string :url, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_03_203646) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_03_213853) do
   create_table "assignments", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "title", null: false
@@ -22,6 +22,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_03_203646) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_assignments_on_user_id"
+  end
+
+  create_table "selected_documents", force: :cascade do |t|
+    t.integer "assignment_id", null: false
+    t.string "google_doc_id", null: false
+    t.string "title", null: false
+    t.string "url", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["assignment_id"], name: "index_selected_documents_on_assignment_id"
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -56,6 +66,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_03_203646) do
   end
 
   add_foreign_key "assignments", "users"
+  add_foreign_key "selected_documents", "assignments"
   add_foreign_key "sessions", "users"
   add_foreign_key "user_tokens", "users"
 end

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Updated `application.html.erb` and `home/index.html.erb` with tailwind classes.
 - Added Assignment model with validations for title, instructions, grade level, and feedback tone.
 - Added SelectedDocument model with validations for assignment, google_doc_id, title, and url.
+- Added "Just finished" to home page.
 
 ### Removed
 - Removed all classes from `application.html.erb` and `home/index.html.erb`, created backups of each.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Added favicon.
 - Updated `application.html.erb` and `home/index.html.erb` with tailwind classes.
 - Added Assignment model with validations for title, instructions, grade level, and feedback tone.
+- Added SelectedDocument model with validations for assignment, google_doc_id, title, and url.
 
 ### Removed
 - Removed all classes from `application.html.erb` and `home/index.html.erb`, created backups of each.

--- a/tasks/task_015.txt
+++ b/tasks/task_015.txt
@@ -1,6 +1,6 @@
 # Task ID: 15
 # Title: Create SelectedDocument model and migration
-# Status: in-progress
+# Status: done
 # Dependencies: 14
 # Priority: high
 # Description: Implement the SelectedDocument model for Google Doc selections

--- a/tasks/task_016.txt
+++ b/tasks/task_016.txt
@@ -1,6 +1,6 @@
 # Task ID: 16
 # Title: Create Rubric model and migration
-# Status: pending
+# Status: in-progress
 # Dependencies: 14
 # Priority: high
 # Description: Implement the Rubric model for structured grading rubrics

--- a/tasks/tasks.json
+++ b/tasks/tasks.json
@@ -173,7 +173,7 @@
       "id": 15,
       "title": "Create SelectedDocument model and migration",
       "description": "Implement the SelectedDocument model for Google Doc selections",
-      "status": "in-progress",
+      "status": "done",
       "dependencies": [
         14
       ],
@@ -185,7 +185,7 @@
       "id": 16,
       "title": "Create Rubric model and migration",
       "description": "Implement the Rubric model for structured grading rubrics",
-      "status": "pending",
+      "status": "in-progress",
       "dependencies": [
         14
       ],

--- a/test/fixtures/selected_documents.yml
+++ b/test/fixtures/selected_documents.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one:
+  assignment: english_essay
+  google_doc_id: "test_google_doc_id"
+  title: "Test Document"
+  url: "https://example.com/test_document"

--- a/test/models/selected_document_test.rb
+++ b/test/models/selected_document_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class SelectedDocumentTest < ActiveSupport::TestCase
+  test "is not valid without assignment" do
+    selected_document = SelectedDocument.new(google_doc_id: "test_id", title: "test_title", url: "test_url")
+    assert_not selected_document.valid?
+  end
+
+  test "is not valid without google_doc_id" do
+    selected_document = SelectedDocument.new(assignment: assignments(:english_essay), title: "test_title", url: "test_url")
+    assert_not selected_document.valid?
+  end
+
+  test "is not valid without title" do
+    selected_document = SelectedDocument.new(assignment: assignments(:english_essay), google_doc_id: "test_id", url: "test_url")
+    assert_not selected_document.valid?
+  end
+
+  test "is not valid without url" do
+    selected_document = SelectedDocument.new(assignment: assignments(:english_essay), google_doc_id: "test_id", title: "test_title")
+    assert_not selected_document.valid?
+  end
+
+  test "is valid with all required attributes" do
+    selected_document = SelectedDocument.new(assignment: assignments(:english_essay), google_doc_id: "test_id", title: "test_title", url: "test_url")
+    assert selected_document.valid?
+  end
+end


### PR DESCRIPTION
This pull request introduces the `SelectedDocument` model, its associated database migration, schema updates, and tests. It also includes updates to the home page, changelog, and task tracking files to reflect the completion of this feature. Below is a summary of the most important changes:

### Model and Database Changes:
* Added the `SelectedDocument` model with `belongs_to :assignment` and validations for `assignment`, `google_doc_id`, `title`, and `url` (`app/models/selected_document.rb`).
* Created a migration to define the `selected_documents` table with appropriate columns, references, and timestamps (`db/migrate/20250503213853_create_selected_documents.rb`).
* Updated `db/schema.rb` to include the `selected_documents` table and its foreign key constraint (`db/schema.rb`) [[1]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R13) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R27-R36) [[3]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R69).

### Tests and Fixtures:
* Added model tests for `SelectedDocument` to ensure validation of required attributes (`test/models/selected_document_test.rb`).
* Created fixtures for the `SelectedDocument` model to support testing (`test/fixtures/selected_documents.yml`).

### Documentation and UI Updates:
* Updated the home page to include a new message indicating the completion of the `SelectedDocument` model (`app/views/home/index.html.erb`).
* Documented the addition of the `SelectedDocument` model in the changelog (`docs/changelog.md`).

### Task Tracking:
* Marked Task 15 ("Create SelectedDocument model and migration") as done and moved Task 16 ("Create Rubric model and migration") to in-progress in the task files (`tasks/task_015.txt`, `tasks/task_016.txt`, `tasks/tasks.json`) [[1]](diffhunk://#diff-ce82bb1887382b5d766be0732d41babbb8d67f9948f6e7e4b209f559157e490eL3-R3) [[2]](diffhunk://#diff-cfea14254940fcb854036f0ecbb877ee06045d18e88f1577b4ac5f4ef0466105L3-R3) [[3]](diffhunk://#diff-7c67ddf2fa5fd5e776ab621040c104fc0acd4b7bef7132aab2c8ebc7e8292c7fL176-R176) [[4]](diffhunk://#diff-7c67ddf2fa5fd5e776ab621040c104fc0acd4b7bef7132aab2c8ebc7e8292c7fL188-R188).