### PR TITLE
FIX: Rename create llm request migration

### DIFF
--- a/db/migrate/20250504144221_create_llm_requests.rb
+++ b/db/migrate/20250504144221_create_llm_requests.rb
@@ -1,4 +1,4 @@
-class CreateLlmRequests < ActiveRecord::Migration[8.0]
+class CreateLLMRequests < ActiveRecord::Migration[8.0]
   def change
     create_table :llm_requests do |t|
       t.references :trackable, polymorphic: true, null: false


### PR DESCRIPTION
This pull request includes a small change to the `db/migrate/20250504144221_create_llm_requests.rb` file. The change updates the class name from `CreateLlmRequests` to `CreateLLMRequests` to follow proper capitalization conventions.