### PR TITLE
FEATURE: Create retry handler task 39

### DIFF
--- a/app/lib/llm/retry_handler.rb
+++ b/app/lib/llm/retry_handler.rb
@@ -1,0 +1,109 @@
+require_relative "client"
+
+module LLM
+  # Retries failed LLM requests with exponential backoff
+  class RetryHandler
+    DEFAULT_MAX_RETRIES = 3
+    DEFAULT_BASE_DELAY = 1 # second
+    DEFAULT_MAX_DELAY = 30 # seconds
+    RETRIABLE_ERRORS = [ LLM::RateLimitError, LLM::ServiceUnavailableError ].freeze
+    JITTER_PERCENTAGE = 0.2 # 20% jitter
+
+    # Executes a block with automatic retry behavior
+    def self.with_retry(**options, &block)
+      new(**options).with_retry(&block)
+    end
+
+    attr_reader :attempt_logs
+
+    def initialize(max_retries: DEFAULT_MAX_RETRIES,
+                  base_delay: DEFAULT_BASE_DELAY,
+                  max_delay: DEFAULT_MAX_DELAY,
+                  retriable_errors: RETRIABLE_ERRORS)
+      @max_retries = max_retries
+      @base_delay = base_delay
+      @max_delay = max_delay
+      @retriable_errors = retriable_errors
+      @retries = 0
+    end
+
+    def with_retry
+      begin
+        yield
+      rescue StandardError => error
+        log_retry_attempt(error)
+
+        if can_retry?(error)
+          increment_retry_count
+          pause_before_retry
+          retry
+        end
+
+        raise error
+      end
+    end
+
+    private
+
+    def retry_count
+      @retries
+    end
+
+    def increment_retry_count
+      @retries += 1
+    end
+
+    def can_retry?(error)
+      under_retry_limit? && retriable_error?(error) && circuit_allows_retry?
+    end
+
+    def under_retry_limit?
+      @retries < @max_retries
+    end
+
+    def retriable_error?(error)
+      @retriable_errors.any? { |err| error.is_a?(err) }
+    end
+
+    def circuit_allows_retry?
+      !circuit_breaker_open?
+    end
+
+    # Placeholder for future circuit breaker integration
+    def circuit_breaker_open?
+      false
+    end
+
+    def pause_before_retry
+      sleep(backoff)
+    end
+
+    def backoff
+      apply_jitter(exponential_delay)
+    end
+
+    def exponential_delay
+      # Formula: base_delay * 2^(retry_count-1)
+      # For retry 1: base_delay * 1
+      # For retry 2: base_delay * 2
+      # For retry 3: base_delay * 4, etc.
+      raw_delay = @base_delay * (2 ** (retry_count - 1))
+      [ raw_delay, @max_delay ].min
+    end
+
+    def apply_jitter(delay)
+      jitter_factor = 1.0 + random_jitter_percentage
+      [ delay * jitter_factor, 0 ].max
+    end
+
+    def random_jitter_percentage
+      (rand * 2 - 1) * JITTER_PERCENTAGE
+    end
+
+    def log_retry_attempt(error)
+      Rails.logger.warn(
+        "[LLM::RetryHandler] Retry #{retry_count + 1} for #{error.class.name}: #{error.message}"
+      )
+    end
+  end
+end

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Ensured proper handling of Google Gemini API response structure in the LLM client
 - Implemented `LLM::ClientFactory` with task-specific methods for selecting appropriate LLM providers
 - Added factory methods for rubric generation (Google), student work feedback (Anthropic), and assignment summary feedback (Anthropic)
+- Implemented `LLM::RetryHandler` with exponential backoff and jitter for handling transient API failures
 
 ## [2025-05-17]
 - Created `Rubric::CreationService` to handle rubric creation for assignments

--- a/tasks/task_039.txt
+++ b/tasks/task_039.txt
@@ -1,6 +1,6 @@
 # Task ID: 39
 # Title: Implement LLM::RetryHandler
-# Status: pending
+# Status: done
 # Dependencies: 35
 # Priority: high
 # Description: Create retry mechanism for handling LLM request failures

--- a/tasks/task_040.txt
+++ b/tasks/task_040.txt
@@ -1,6 +1,6 @@
 # Task ID: 40
 # Title: Implement LLM::CircuitBreaker
-# Status: pending
+# Status: in-progress
 # Dependencies: 39
 # Priority: high
 # Description: Create circuit breaker for preventing cascading failures

--- a/tasks/tasks.json
+++ b/tasks/tasks.json
@@ -467,7 +467,7 @@
       "id": 39,
       "title": "Implement LLM::RetryHandler",
       "description": "Create retry mechanism for handling LLM request failures",
-      "status": "pending",
+      "status": "done",
       "dependencies": [
         35
       ],
@@ -479,7 +479,7 @@
       "id": 40,
       "title": "Implement LLM::CircuitBreaker",
       "description": "Create circuit breaker for preventing cascading failures",
-      "status": "pending",
+      "status": "in-progress",
       "dependencies": [
         39
       ],

--- a/test/lib/llm/retry_handler_test.rb
+++ b/test/lib/llm/retry_handler_test.rb
@@ -1,0 +1,116 @@
+require "test_helper"
+require_relative "../../../app/lib/llm/client"
+
+class LLM::RetryHandlerTest < ActiveSupport::TestCase
+  test "retries specified number of times and eventually succeeds" do
+    call_count = 0
+
+    result = LLM::RetryHandler.with_retry(max_retries: 3, base_delay: 0.01, max_delay: 0.05) do
+      call_count += 1
+
+      if call_count < 3
+        raise LLM::ServiceUnavailableError, "Service temporarily unavailable"
+      end
+
+      "success"
+    end
+
+    assert_equal 3, call_count
+    assert_equal "success", result
+  end
+
+  test "gives up after max retries and raises the last error" do
+    call_count = 0
+
+    assert_raises(LLM::ServiceUnavailableError) do
+      LLM::RetryHandler.with_retry(max_retries: 2, base_delay: 0.01, max_delay: 0.05) do
+        call_count += 1
+        raise LLM::ServiceUnavailableError, "Service unavailable"
+      end
+    end
+
+    assert_equal 3, call_count # initial + 2 retries
+  end
+
+  test "doesn't retry for non-retriable errors" do
+    call_count = 0
+
+    assert_raises(LLM::PromptValidationError) do
+      LLM::RetryHandler.with_retry(max_retries: 3, base_delay: 0.01, max_delay: 0.05) do
+        call_count += 1
+        raise LLM::PromptValidationError, "Invalid prompt"
+      end
+    end
+
+    assert_equal 1, call_count # no retries
+  end
+
+  test "uses exponential backoff for retry delays" do
+    delays = []
+
+    # Mock the sleep method on the instance
+    original_instance_method = LLM::RetryHandler.instance_method(:sleep)
+
+    LLM::RetryHandler.define_method(:sleep) do |seconds|
+      delays << seconds
+      # Don't actually sleep in tests
+    end
+
+    begin
+      assert_raises(LLM::ServiceUnavailableError) do
+        LLM::RetryHandler.with_retry(max_retries: 3, base_delay: 0.1, max_delay: 10) do
+          raise LLM::ServiceUnavailableError, "Service unavailable"
+        end
+      end
+
+      assert_equal 3, delays.length
+
+      # Check that delays increase exponentially (allowing for jitter)
+      assert delays[1] > delays[0], "Second delay should be greater than first"
+      assert delays[2] > delays[1], "Third delay should be greater than second"
+
+      # Base delay is 0.1, so first retry should be between 0.08 and 0.12 (±20% jitter)
+      assert_includes 0.08..0.12, delays[0]
+
+      # Second retry should be around 0.2 (2*base_delay) with jitter
+      assert_includes 0.16..0.24, delays[1]
+
+      # Third retry should be around 0.4 (4*base_delay) with jitter
+      assert_includes 0.32..0.48, delays[2]
+    ensure
+      # Restore original sleep method
+      LLM::RetryHandler.define_method(:sleep, original_instance_method)
+    end
+  end
+
+  test "respects max_delay setting" do
+    delays = []
+
+    # Mock the sleep method on the instance
+    original_instance_method = LLM::RetryHandler.instance_method(:sleep)
+
+    LLM::RetryHandler.define_method(:sleep) do |seconds|
+      delays << seconds
+      # Don't actually sleep in tests
+    end
+
+    begin
+      assert_raises(LLM::ServiceUnavailableError) do
+        LLM::RetryHandler.with_retry(max_retries: 5, base_delay: 1, max_delay: 2) do
+          raise LLM::ServiceUnavailableError, "Service unavailable"
+        end
+      end
+
+      # All delays should be at most max_delay + jitter
+      delays.each do |delay|
+        assert delay <= 2.4, "Delay #{delay} exceeds max_delay + 20% jitter"
+      end
+
+      # Later delays should hit the max
+      assert_in_delta 2, delays.last, 0.4, "Later delays should approach max_delay"
+    ensure
+      # Restore original sleep method
+      LLM::RetryHandler.define_method(:sleep, original_instance_method)
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces a new `LLM::RetryHandler` class to handle transient API failures using an exponential backoff strategy with jitter. It also includes updates to task statuses, documentation, and comprehensive tests for the new functionality.

### New Feature: Retry Mechanism for LLM Requests
* Added `LLM::RetryHandler` class to implement retries for failed LLM requests with exponential backoff, jitter, and configurable retry limits. The class handles specific retriable errors (`LLM::RateLimitError`, `LLM::ServiceUnavailableError`) and includes placeholders for future circuit breaker integration. (`app/lib/llm/retry_handler.rb`, [app/lib/llm/retry_handler.rbR1-R109](diffhunk://#diff-e851efc8bc561e193611a7d48f2e7b74eff6752237e4848fbad634b3b02ca02bR1-R109))

### Documentation Updates
* Updated the changelog to document the addition of `LLM::RetryHandler`. (`docs/changelog.md`, [docs/changelog.mdR10](diffhunk://#diff-77f023b99d3d58008351d3e82fc06e6d06ba1bc2da9e41be6329b7fa4f419f05R10))

### Task Management
* Marked task 39 ("Implement LLM::RetryHandler") as done in both `tasks/task_039.txt` and `tasks/tasks.json`. (`tasks/task_039.txt`, [[1]](diffhunk://#diff-7943be48e7ca2fea4f16dde306f874247f1c0575c619c6c2e440120b317bf2c3L3-R3); `tasks/tasks.json`, [[2]](diffhunk://#diff-7c67ddf2fa5fd5e776ab621040c104fc0acd4b7bef7132aab2c8ebc7e8292c7fL470-R470)
* Updated task 40 ("Implement LLM::CircuitBreaker") to "in-progress" status in both `tasks/task_040.txt` and `tasks/tasks.json`. (`tasks/task_040.txt`, [[1]](diffhunk://#diff-81333c1da9ef8a05610b3dbccdf41bbeb60f14ef6afc8fa0c58eb695b7abccefL3-R3); `tasks/tasks.json`, [[2]](diffhunk://#diff-7c67ddf2fa5fd5e776ab621040c104fc0acd4b7bef7132aab2c8ebc7e8292c7fL482-R482)

### Testing
* Added comprehensive tests for `LLM::RetryHandler` to verify retry behavior, exponential backoff with jitter, handling of non-retriable errors, and adherence to `max_delay`. Tests ensure the correct number of retries, proper delay calculations, and respect for configuration limits. (`test/lib/llm/retry_handler_test.rb`, [test/lib/llm/retry_handler_test.rbR1-R116](diffhunk://#diff-b8cd94bf3db10b4b271465b04ef274e300b0538e93f008fb06aacc3ef4b1e3ccR1-R116))