### PR TITLE
Fix inconsistent tile spacing on student work show page

### DIFF
--- a/app/views/student_works/show.html.erb
+++ b/app/views/student_works/show.html.erb
@@ -27,27 +27,27 @@
     <div class="grid grid-cols-1 lg:grid-cols-5 gap-6 mb-6">
       <!-- Overall Performance Badge -->
       <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-        <h3 class="text-sm font-medium text-gray-600 mb-2">Overall performance</h3>
+        <h3 class="text-sm font-medium text-gray-600 mb-2 min-h-[2.5rem] flex items-center">Overall performance</h3>
         <%= render "shared/performance_badge", level: @student_work.high_level_feedback_average %>
       </div>
 
       <!-- Strengths Count -->
       <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-        <h3 class="text-sm font-medium text-gray-600 mb-2">Strengths identified</h3>
+        <h3 class="text-sm font-medium text-gray-600 mb-2 min-h-[2.5rem] flex items-center">Strengths identified</h3>
         <p class="text-3xl font-bold text-green-600"><%= @student_work.feedback_items.strengths.count %></p>
         <p class="text-sm text-gray-500 mt-1">Key areas of excellence</p>
       </div>
 
       <!-- Growth Areas Count -->
       <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-        <h3 class="text-sm font-medium text-gray-600 mb-2">Growth areas</h3>
+        <h3 class="text-sm font-medium text-gray-600 mb-2 min-h-[2.5rem] flex items-center">Growth areas</h3>
         <p class="text-3xl font-bold text-amber-600"><%= @student_work.feedback_items.opportunities.count %></p>
         <p class="text-sm text-gray-500 mt-1">Opportunities to improve</p>
       </div>
 
       <!-- Plagiarism Check -->
       <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-        <h3 class="text-sm font-medium text-gray-600 mb-2">Plagiarism check</h3>
+        <h3 class="text-sm font-medium text-gray-600 mb-2 min-h-[2.5rem] flex items-center">Plagiarism check</h3>
         <% plagiarism_check = @student_work.student_work_checks.plagiarism.first %>
         <% if plagiarism_check %>
           <% score = plagiarism_check.score.to_i %>
@@ -62,7 +62,7 @@
 
       <!-- AI Detection -->
       <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-        <h3 class="text-sm font-medium text-gray-600 mb-2">AI detection</h3>
+        <h3 class="text-sm font-medium text-gray-600 mb-2 min-h-[2.5rem] flex items-center">AI detection</h3>
         <% ai_check = @student_work.student_work_checks.llm_generated.first %>
         <% if ai_check %>
           <% score = ai_check.score.to_i %>


### PR DESCRIPTION
## Summary
- Fixes uneven spacing between tiles on medium screens caused by variable header text length
- Ensures consistent visual layout regardless of header text wrapping

## Problem
The five tiles at the top of the student work show page had inconsistent heights because headers like "Strengths identified" and "Plagiarism check" can wrap to 2 lines on medium screens, while others like "Growth areas" stay on 1 line. This created uneven spacing that undermined the polished UX.

## Solution
Added `min-h-[2.5rem] flex items-center` to all tile headers to:
- Ensure consistent minimum height for all headers
- Center text vertically whether it's 1 or 2 lines
- Maintain visual alignment across all tiles

## Changes
- Updated 5 header elements in `app/views/student_works/show.html.erb`
- Used Tailwind's `min-h-[2.5rem]` for reliable cross-browser support
- Added `flex items-center` for proper vertical centering

## Test plan
- [x] All tests pass (`bin/check`)
- [ ] Verify consistent tile heights on medium screens (768px-1024px)
- [ ] Check that headers still wrap properly when needed
- [ ] Confirm visual alignment is improved

## Before/After
**Before:** Tiles had uneven heights when headers wrapped
**After:** All tiles maintain consistent spacing regardless of header length

🤖 Generated with [Claude Code](https://claude.ai/code)